### PR TITLE
feat(defaulttsconfig): expores getDefaultTsConfig method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Anyway, because English is the language of programming, the code, including vari
 Installation is done using `npm install` command:
 
 ```bash
-$ npm install --save-dev ts-transform-test-compiler
+npm install --save-dev ts-transform-test-compiler
 ```
 
 If you prefer using `yarn`:
 
 ```bash
-$ yarn add --dev ts-transform-test-compiler
+yarn add --dev ts-transform-test-compiler
 ```
 
 # Usage
@@ -58,6 +58,10 @@ describe('My test suite', function() {
 # API
 
 ## Compiler
+
+## Getting default CompilerOptions
+
+Exposed method `getDefaultTsConfig()` to retrieve the default compiler options so the user is able to overwrite or extend the default options to apply it on Compiler constructor afterwards
 
 ### constructor(transformer: Transformer, outDir: string, compilerOptions?: CompilerOptions)
 

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -29,6 +29,8 @@ const defaultTsConfig: CompilerOptions = {
   target: ScriptTarget.ES2015,
 }
 
+export const getDefaultTsConfig = (): CompilerOptions => defaultTsConfig;
+
 /**
  * Typescript compiler for transformer testing.
  */

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -29,7 +29,7 @@ const defaultTsConfig: CompilerOptions = {
   target: ScriptTarget.ES2015,
 }
 
-export const getDefaultTsConfig = (): CompilerOptions => defaultTsConfig;
+export const getDefaultTsConfig = (): CompilerOptions => defaultTsConfig
 
 /**
  * Typescript compiler for transformer testing.
@@ -65,14 +65,18 @@ export default class Compiler {
    *
    * @param transformer - The transformer function to test.
    * @param outDir - The directory where compilation result will be emitted.
-   * @param compilerOptions - The compiler options, if default options do not fit. As they may change for
+   * @param _compilerOptions - The compiler options, if default options do not fit. As they may change for
    * each test, `rootDir` and `outDir` should not be set here (will be overriden at each compilation).
    */
   public constructor(
     private readonly transformer: TransformerMetaFactory,
     private readonly outDir: string,
-    private readonly compilerOptions: CompilerOptions = defaultTsConfig
+    private readonly _compilerOptions: CompilerOptions = defaultTsConfig
   ) {}
+
+  public get compilerOptions() {
+    return this._compilerOptions
+  }
 
   /**
    * Set the transformer hook (the phase when transformer is to be called).

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,7 +11,7 @@ import {
   visitNode,
 } from 'typescript'
 
-import Compiler from '.'
+import Compiler, { getDefaultTsConfig } from '.'
 
 function noopTransformer(): TransformerFactory<SourceFile> {
   return (): Transformer<SourceFile> => (sf: SourceFile) => visitNode(sf, (node: Node) => node)
@@ -86,5 +86,22 @@ describe('Compiler', function() {
     const output = catchOutput(() => result.print())
     expect(result.succeeded).to.be.false
     expect(output).to.be.match(/is not assignable/)
+  })
+})
+
+describe('getDefaultTsConfig', () => {
+  it('returns default CompilerOptions', function() {
+    const compiler = new Compiler(noopTransformer, 'dist/__test__')
+
+    expect(getDefaultTsConfig()).equal(compiler.compilerOptions)
+  })
+
+  it('Compiler can extend defaultTsConfig', function() {
+    const defaultOptions = getDefaultTsConfig()
+    const extendedConfig = Object.assign(getDefaultTsConfig(), { experimentalDecorators: false })
+    const compiler = new Compiler(noopTransformer, 'dist/__test__', extendedConfig)
+
+    expect(compiler.compilerOptions.noEmitOnError).equal(defaultOptions.noEmitOnError)
+    expect(compiler.compilerOptions.experimentalDecorators).equal(false)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default } from './Compiler'
+export { default, getDefaultTsConfig } from './Compiler'
 export { default as CompilationResult } from './CompilationResult'


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
expose `getDefaultTsConfig` options

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To open the door to be able to construct a `Compiler` extending `defaultTsOptions`

Fix #1 